### PR TITLE
Tera 3371 implement clipping

### DIFF
--- a/src/main/scala/com/clarify/prediction/explainer/GLMExplainTransformer.scala
+++ b/src/main/scala/com/clarify/prediction/explainer/GLMExplainTransformer.scala
@@ -308,9 +308,9 @@ class GLMExplainTransformer(override val uid: String)
          |else pow(${x},${y}) end""".stripMargin
 
     case ("binomial", x, y, _) =>
-      s"""case when  pow(${x},${y}) < ${epsilon} then ${epsilon}
-         |when  pow(${x},${y}) > 1.0-${epsilon} then 1.0-${epsilon}
-         |else  pow(${x},${y}) end""".stripMargin
+      s"""case when pow(${x},${y}) < ${epsilon} then ${epsilon}
+         |when pow(${x},${y}) > 1.0-${epsilon} then 1.0-${epsilon}
+         |else pow(${x},${y}) end""".stripMargin
 
     case ("tweedie" | "poisson" | "gamma", x, y, _) =>
       s"""case when pow(${x},${y})  < ${epsilon} then ${epsilon} 


### PR DESCRIPTION
@imanclarify . 
I have updated the solution to match with spark implementation 

https://github.com/apache/spark/blob/master/mllib/src/main/scala/org/apache/spark/ml/regression/GeneralizedLinearRegression.scala

Look at the `project` method we have the default base implementation and specific family overrides it.

Base Implementation 
```
override def project(mu: Double): Double = {
      if (mu < epsilon) {
        epsilon
      } else if (mu.isInfinity) {
        Double.MaxValue
      } else {
        mu
      }
    }
```
Gaussian and `Tweedie`  with variancePower = 0.0
```
 override def project(mu: Double): Double = {
      if (mu.isNegInfinity) {
        Double.MinValue
      } else if (mu.isPosInfinity) {
        Double.MaxValue
      } else {
        mu
      }
```
Binomial only
```
 override def project(mu: Double): Double = {
      if (mu < epsilon) {
        epsilon
      } else if (mu > 1.0 - epsilon) {
        1.0 - epsilon
      } else {
        mu
      }
    }
```
