### PR TITLE
Calculate Disruption

### DIFF
--- a/src/main/scala/com/clarify/disruption/v1/Calculator.scala
+++ b/src/main/scala/com/clarify/disruption/v1/Calculator.scala
@@ -22,7 +22,13 @@ class Calculator extends UDF1[Seq[Double], Double] {
     val y_mean = y_values.sum / y_values_length
     val linear_predictions = x_values.map(x => slope * x + y_mean)
 
-    new StdDev().call(linear_predictions)
+    val residuals = linear_predictions.zip(y_values).map {
+      case (predicted, actual) => predicted - actual
+    }
+
+    val residual_stddev = new StdDev().call(residuals)
+
+    residual_stddev
 
   }
 }

--- a/src/main/scala/com/clarify/disruption/v1/Calculator.scala
+++ b/src/main/scala/com/clarify/disruption/v1/Calculator.scala
@@ -1,0 +1,28 @@
+package com.clarify.disruption.v1
+
+import com.clarify.array.StdDev
+import org.apache.spark.sql.api.java.UDF1
+
+import scala.math.pow
+
+class Calculator extends UDF1[Seq[Double], Double] {
+  override def call(data: Seq[Double]): Double = {
+    // data is the array that we get from the convolution process
+
+    // Calculating the linear regression
+    val y_values = data
+    val y_values_length = data.length
+    val x_values =
+      Array.range(-(y_values_length - 1) / 2, (y_values_length - 1) / 2 + 1)
+
+    val sigma_x2 = x_values.map(x => pow(x, 2)).sum
+    val sigma_xy = x_values.zip(y_values).map { case (x, y) => x * y }.sum
+
+    val slope = (sigma_xy) / sigma_x2
+    val y_mean = y_values.sum / y_values_length
+    val linear_predictions = x_values.map(x => slope * x + y_mean)
+
+    new StdDev().call(linear_predictions)
+
+  }
+}

--- a/src/test/scala/com/clarify/disruption/v1/CalculatorTest.scala
+++ b/src/test/scala/com/clarify/disruption/v1/CalculatorTest.scala
@@ -1,0 +1,43 @@
+package com.clarify.disruption.v1
+
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.types.DataTypes
+import com.clarify.sparse_vectors.SparkSessionTestWrapper
+
+import scala.util.Random
+
+class CalculatorTest extends QueryTest with SparkSessionTestWrapper {
+  test("basic test") {
+
+    val test_data = Seq.fill(20)((Random.nextDouble() * 2) + 20) ++ Seq.fill(
+      12
+    )(
+      (Random.nextDouble() * 2) + 5
+    )
+
+    val test_data_cast_double = test_data.map(x => s"cast(${x} as double)")
+
+    val testDF = spark.sql(
+      s"select array(${test_data_cast_double.mkString(",")})  as data"
+    )
+
+    spark.udf.register(
+      "calculate_disruption",
+      new Calculator(),
+      DataTypes.DoubleType
+    )
+
+    val resultDF = testDF.selectExpr(
+      "data",
+      "calculate_disruption(data) as calculated_disruption"
+    )
+    checkAnswer(
+      resultDF.selectExpr(
+        "case when calculated_disruption between 5 and 6 then 1 else 0 end as result"
+      ),
+      spark.sql("select 1 as result")
+    )
+
+  }
+
+}

--- a/src/test/scala/com/clarify/disruption/v1/CalculatorTest.scala
+++ b/src/test/scala/com/clarify/disruption/v1/CalculatorTest.scala
@@ -31,9 +31,12 @@ class CalculatorTest extends QueryTest with SparkSessionTestWrapper {
       "data",
       "calculate_disruption(data) as calculated_disruption"
     )
+
+    resultDF.show(truncate = false)
+
     checkAnswer(
       resultDF.selectExpr(
-        "case when calculated_disruption between 5 and 6 then 1 else 0 end as result"
+        "case when calculated_disruption between 2 and 5 then 1 else 0 end as result"
       ),
       spark.sql("select 1 as result")
     )


### PR DESCRIPTION
1. The new UDF to calculate disruption with direction `src/main/scala/com/clarify/disruption/v1/Calculator.scala`
2. Added the `v1` as package so we can iterate and improve in near future.
3. Added unit test.