### PR TITLE
Tera 6429 unit test v3 disruption

### DIFF
--- a/src/main/scala/com/clarify/disruption/v3/Calculator.scala
+++ b/src/main/scala/com/clarify/disruption/v3/Calculator.scala
@@ -18,6 +18,7 @@ class Calculator extends UDF1[Seq[Double], Option[Double]] {
     // use value or -1 if there is no value
     val out: Option[Double] = diff.lift(index.getOrElse(-1))
 
+    // change any value greater than 0 to 0 so we get only negative disruption
     Some(Array(out.getOrElse(0.0), 0.0).min)
 
   }

--- a/src/main/scala/com/clarify/disruption/v3/Calculator.scala
+++ b/src/main/scala/com/clarify/disruption/v3/Calculator.scala
@@ -7,12 +7,16 @@ import scala.util.Try
 class Calculator extends UDF1[Seq[Double], Option[Double]] {
   override def call(data: Seq[Double]): Option[Double] = {
 
-    val diff = for (i <- 1 until data.length)
+    // calculate the delta for each reading (subtracting the previous entry from it)
+    val diff: IndexedSeq[Double] = for (i <- 1 until data.length)
       yield data(i) - data(i - 1)
 
-    val index = Try(diff.indices.minBy(x => x)).toOption
+    // find index of element with the minimum value
+//    val index = Try(diff.indices.minBy(x => x)).toOption
+    val index: Option[Int] = Try(diff.indices.minBy(diff)).toOption
 
-    val out = diff.lift(index.getOrElse(-1))
+    // use value or -1 if there is no value
+    val out: Option[Double] = diff.lift(index.getOrElse(-1))
 
     Some(Array(out.getOrElse(0.0), 0.0).min)
 

--- a/src/test/scala/com/clarify/disruption/v3/CalculatorTest.scala
+++ b/src/test/scala/com/clarify/disruption/v3/CalculatorTest.scala
@@ -1,0 +1,52 @@
+package com.clarify.disruption.v3
+
+import com.clarify.sparse_vectors.SparkSessionTestWrapper
+import org.apache.spark.sql.QueryTest
+import org.apache.spark.sql.types.DataTypes
+
+class CalculatorTest extends QueryTest with SparkSessionTestWrapper {
+  test("direct test max at beginning") {
+    val calculator = new Calculator()
+    val data: Seq[Double] = Seq(2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
+    val result: Option[Double] = calculator.call(data)
+    assert(result.isDefined)
+    assert(result.get == -0.3333333333333335)
+  }
+  test("direct test max in the middle") {
+    val calculator = new Calculator()
+    val data: Seq[Double] = Seq(2.0, 2,0, 2,0, 2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0)
+    val result: Option[Double] = calculator.call(data)
+    assert(result.isDefined)
+    assert(result.get == -2.0)
+  }
+  test("basic test") {
+
+    val testDF = spark.sql(
+      s"select cast(array(2.0, 2,0, 2,0, 2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0) as array<double>) as data"
+    )
+
+    spark.udf.register(
+      "calculate_disruption",
+      new Calculator(),
+      DataTypes.DoubleType
+    )
+
+    val resultDF = testDF.selectExpr(
+      "data",
+      "calculate_disruption(data) as calculated_disruption"
+    )
+
+    resultDF.show(truncate = false)
+
+    resultDF.printSchema()
+
+    checkAnswer(
+      resultDF.selectExpr(
+        "calculated_disruption as result"
+      ),
+      spark.sql("select cast(-2.0 as double) as result")
+    )
+
+  }
+
+}

--- a/src/test/scala/com/clarify/disruption/v3/CalculatorTest.scala
+++ b/src/test/scala/com/clarify/disruption/v3/CalculatorTest.scala
@@ -5,26 +5,40 @@ import org.apache.spark.sql.QueryTest
 import org.apache.spark.sql.types.DataTypes
 
 class CalculatorTest extends QueryTest with SparkSessionTestWrapper {
-  test("direct test max at beginning") {
+  test("direct test max delta at beginning") {
     val calculator = new Calculator()
     val data: Seq[Double] = Seq(2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0)
     val result: Option[Double] = calculator.call(data)
     assert(result.isDefined)
     assert(result.get == -0.3333333333333335)
   }
-  test("direct test max in the middle") {
+  test("direct test max delta in the middle") {
     val calculator = new Calculator()
     val data: Seq[Double] = Seq(2.0, 2.0, 0.0, 2.0, 0.0 , 2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0)
     val result: Option[Double] = calculator.call(data)
     assert(result.isDefined)
     assert(result.get == -2.0)
   }
-  test("direct test max at the end") {
+  test("direct test max delta at the end") {
     val calculator = new Calculator()
     val data: Seq[Double] = Seq(2.0, 2.0, 1.5, 2.0, 1.5 , 2.0, 1.6666666666666665, 1.3333333333333333, 2.0, 2.0, 2.0, 1.0)
     val result: Option[Double] = calculator.call(data)
     assert(result.isDefined)
     assert(result.get == -1.0)
+  }
+  test("direct test quarterly max delta at the beginning") {
+    val calculator = new Calculator()
+    val data: Seq[Double] = Seq(3.0, 1.0, 1.0, 1.0)
+    val result: Option[Double] = calculator.call(data)
+    assert(result.isDefined)
+    assert(result.get == -2.0)
+  }
+  test("direct test quarterly max delta at the end") {
+    val calculator = new Calculator()
+    val data: Seq[Double] = Seq(3.0, 3.0, 3.0, 1.0)
+    val result: Option[Double] = calculator.call(data)
+    assert(result.isDefined)
+    assert(result.get == -2.0)
   }
   test("basic test") {
 

--- a/src/test/scala/com/clarify/disruption/v3/CalculatorTest.scala
+++ b/src/test/scala/com/clarify/disruption/v3/CalculatorTest.scala
@@ -14,10 +14,17 @@ class CalculatorTest extends QueryTest with SparkSessionTestWrapper {
   }
   test("direct test max in the middle") {
     val calculator = new Calculator()
-    val data: Seq[Double] = Seq(2.0, 2,0, 2,0, 2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0)
+    val data: Seq[Double] = Seq(2.0, 2.0, 0.0, 2.0, 0.0 , 2.0, 1.6666666666666665, 1.3333333333333333, 1.0, 1.0, 1.0, 1.0)
     val result: Option[Double] = calculator.call(data)
     assert(result.isDefined)
     assert(result.get == -2.0)
+  }
+  test("direct test max at the end") {
+    val calculator = new Calculator()
+    val data: Seq[Double] = Seq(2.0, 2.0, 1.5, 2.0, 1.5 , 2.0, 1.6666666666666665, 1.3333333333333333, 2.0, 2.0, 2.0, 1.0)
+    val result: Option[Double] = calculator.call(data)
+    assert(result.isDefined)
+    assert(result.get == -1.0)
   }
   test("basic test") {
 


### PR DESCRIPTION
- Also fixed a bug in the calculation of disruption.  it was always using the index of the first element.